### PR TITLE
Remove leftover settings

### DIFF
--- a/control/installation.xml
+++ b/control/installation.xml
@@ -40,9 +40,6 @@ textdomain="control"
 		  <firewall_enable_ssh config:type="boolean">true</firewall_enable_ssh>
 		  <default_ntp_setup config:type="boolean">true</default_ntp_setup>
 		</globals>
-                <partitioning>
-                  <try_separate_home config:type="boolean">false</try_separate_home>
-                </partitioning>
                 <software>
                   <default_patterns>minimal_base ha_sles enhanced_base</default_patterns>
                   <optional_default_patterns><![CDATA[]]></optional_default_patterns>
@@ -57,9 +54,6 @@ textdomain="control"
 		  <firewall_enable_ssh config:type="boolean">true</firewall_enable_ssh>
 		  <default_ntp_setup config:type="boolean">true</default_ntp_setup>
 		</globals>
-		<partitioning>
-                  <try_separate_home config:type="boolean">false</try_separate_home>
-                </partitioning>
                 <software>
                   <default_patterns>minimal_base ha_sles ha_geo enhanced_base</default_patterns>
                   <optional_default_patterns><![CDATA[]]></optional_default_patterns>

--- a/package/system-role-ha.changes
+++ b/package/system-role-ha.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 15 15:52:38 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Remove partitioning section. That setting were useless because
+  they were expressed in the old format used before SLE-15
+  (bsc#1192694).
+- 15.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 15.4.0 (bsc#1185510)

--- a/package/system-role-ha.spec
+++ b/package/system-role-ha.spec
@@ -36,7 +36,7 @@ BuildRequires:  yast2-installation-control >= 4.0.0
 
 Url:            https://github.com/yast/system-role-ha
 AutoReqProv:    off
-Version:        15.4.0
+Version:        15.4.1
 Release:        0
 Summary:        Server HA role definition
 License:        MIT


### PR DESCRIPTION
## Problem

In SLE-15-GA, the YaST storage stack was replaced by a completely new implementation (a.k.a., storage-ng). The `<partitioning>` section of the control file was also redefined as part of that reimplementation. All products (SLES, SLED, Leap, TW, etc) were adapted to use the new partitioning settings. But this role still uses the old settings format.

When a role is selected, its settings are merged into the the base product settings. In this case, the old partitioning settings are merged into the partitioning setting of the base product. And due to the base product uses the new format, these partitioning settings from the role have no effect at all.

* https://bugzilla.suse.com/show_bug.cgi?id=1192694

## Solution

Remove leftover `<partitioning>` section.
 
Note: the old settings have been useless since SLE-15-GA, but the format validations only fail since this change in master (SLE-15-SP4), where the old partitioning format was completely dropped: https://github.com/yast/yast-installation-control/pull/113.